### PR TITLE
fix(transcoder): renew ack deadline for long transcodes to prevent duplicate processing

### DIFF
--- a/pkg/controllers/transcoder_service.go
+++ b/pkg/controllers/transcoder_service.go
@@ -113,6 +113,30 @@ func (c *RecorderController) startTranscodingService() {
 
 				// All the tasks are a blocking call. The loop will not continue to the next Fetch until this transcoding is finished.
 				started := time.Now()
+
+				// Heartbeat: transcoding is a blocking call that can run for far
+				// longer than the consumer's AckWait (30s by default, as the
+				// consumer sets no explicit AckWait). Without this, JetStream marks
+				// the message for redelivery and a second worker on the shared
+				// work-queue consumer picks up the SAME job -> duplicate concurrent
+				// transcode + a race on rsync --remove-source-files. Periodically
+				// signaling InProgress renews the ack deadline until the transcode
+				// finishes, keeping the job assigned to this worker.
+				hbDone := make(chan struct{})
+				go func() {
+					t := time.NewTicker(15 * time.Second)
+					defer t.Stop()
+					for {
+						select {
+						case <-hbDone:
+							return
+						case <-t.C:
+							if err := msg.InProgress(); err != nil {
+								log.WithError(err).Warnln("Failed to send InProgress heartbeat")
+							}
+						}
+					}
+				}()
 				var procErr error
 				switch v := task.TaskDetails.(type) {
 				case *plugnmeet.TranscodingTask_PostRecording:
@@ -124,6 +148,7 @@ func (c *RecorderController) startTranscodingService() {
 					log.Info("Starting new 'merge_recordings' transcoding task")
 					procErr = c.handleMergeRecordings(task, v.MergeRecordings, log)
 				}
+				close(hbDone) // stop the heartbeat before Ack/Nak
 
 				if procErr != nil {
 					log.WithError(procErr).Warnln("Transcoding failed, sending NAK to re-queue job")

--- a/pkg/controllers/transcoder_service.go
+++ b/pkg/controllers/transcoder_service.go
@@ -114,25 +114,11 @@ func (c *RecorderController) startTranscodingService() {
 				// All the tasks are a blocking call. The loop will not continue to the next Fetch until this transcoding is finished.
 				started := time.Now()
 
-				// Heartbeat: transcoding is a blocking call that can run for far
-				// longer than the consumer's AckWait (30s by default, as the
-				// consumer sets no explicit AckWait). Without this, JetStream marks
-				// the message for redelivery and a second worker on the shared
-				// work-queue consumer picks up the SAME job -> duplicate concurrent
-				// transcode + a race on rsync --remove-source-files. Periodically
-				// signaling InProgress renews the ack deadline until the transcode
-				// finishes, keeping the job assigned to this worker.
-				// hbLog is a stable copy: the switch below reassigns `log`, which the
-				// heartbeat goroutine must not read concurrently. hbStopped lets us
-				// wait for the goroutine to fully exit before Ack/Nak, so InProgress
-				// never races with Ack/NakWithDelay on the same message.
-				//
-				// The heartbeat is intentionally NOT tied to c.ctx: the transcode
-				// itself does not observe ctx, so bailing on cancel would stop
-				// renewing the ack while the transcode keeps running, letting the
-				// message be redelivered to another worker mid-transcode — the exact
-				// duplication this guards against. It exits only via hbDone, once the
-				// (always-terminating) transcode returns.
+				// Heartbeat: renew the ack deadline (msg.InProgress) every 15s so a
+				// transcode longer than the consumer's AckWait isn't redelivered to a
+				// second worker and processed twice. hbLog is a stable copy (the switch
+				// reassigns log); hbStopped lets us wait for the goroutine to exit
+				// before Ack/Nak so InProgress never races with them.
 				hbLog := log
 				hbDone := make(chan struct{})
 				hbStopped := make(chan struct{})

--- a/pkg/controllers/transcoder_service.go
+++ b/pkg/controllers/transcoder_service.go
@@ -122,8 +122,22 @@ func (c *RecorderController) startTranscodingService() {
 				// transcode + a race on rsync --remove-source-files. Periodically
 				// signaling InProgress renews the ack deadline until the transcode
 				// finishes, keeping the job assigned to this worker.
+				// hbLog is a stable copy: the switch below reassigns `log`, which the
+				// heartbeat goroutine must not read concurrently. hbStopped lets us
+				// wait for the goroutine to fully exit before Ack/Nak, so InProgress
+				// never races with Ack/NakWithDelay on the same message.
+				//
+				// The heartbeat is intentionally NOT tied to c.ctx: the transcode
+				// itself does not observe ctx, so bailing on cancel would stop
+				// renewing the ack while the transcode keeps running, letting the
+				// message be redelivered to another worker mid-transcode — the exact
+				// duplication this guards against. It exits only via hbDone, once the
+				// (always-terminating) transcode returns.
+				hbLog := log
 				hbDone := make(chan struct{})
+				hbStopped := make(chan struct{})
 				go func() {
+					defer close(hbStopped)
 					t := time.NewTicker(15 * time.Second)
 					defer t.Stop()
 					for {
@@ -132,7 +146,7 @@ func (c *RecorderController) startTranscodingService() {
 							return
 						case <-t.C:
 							if err := msg.InProgress(); err != nil {
-								log.WithError(err).Warnln("Failed to send InProgress heartbeat")
+								hbLog.WithError(err).Warnln("Failed to send InProgress heartbeat")
 							}
 						}
 					}
@@ -148,7 +162,8 @@ func (c *RecorderController) startTranscodingService() {
 					log.Info("Starting new 'merge_recordings' transcoding task")
 					procErr = c.handleMergeRecordings(task, v.MergeRecordings, log)
 				}
-				close(hbDone) // stop the heartbeat before Ack/Nak
+				close(hbDone) // stop the heartbeat...
+				<-hbStopped   // ...and wait for it to exit before Ack/Nak
 
 				if procErr != nil {
 					log.WithError(procErr).Warnln("Transcoding failed, sending NAK to re-queue job")


### PR DESCRIPTION
## Problem

The transcoding worker's JetStream consumer is created with only `Durable` + `AckExplicitPolicy` and **no `AckWait`**, so it uses JetStream's 30s default. The transcode handler in `startTranscodingService` is a **blocking call** (`handlePostRecordingTranscoding` / `handleMergeRecordings`) that never signals progress, so any transcode running longer than ~30s has its ack deadline expire.

Because the stream uses `WorkQueuePolicy` with a single shared durable consumer (`TranscoderConsumerDurable`), an expired ack makes the message redeliverable and a **second worker fetches the same job**. This happens whenever more than one worker consumes the queue:

- multiple recorders running in `both` mode, or
- a dedicated pool of `transcoderOnly` instances.

The result is a **duplicate concurrent transcode of the same file**, plus a race on `rsync --remove-source-files` of the raw file (one worker removes the source the other is still reading). `NumDelivered` then keeps climbing until `maxTranscodingRetries` (3) drops the job, losing the recording.

Slow transcodes are common and legitimate: large recordings, slow presets (e.g. `-preset veryslow`), CPU-constrained / low-priority transcoders (`nice`/`ionice`), or `-threads 1`.

## Fix

Send `msg.InProgress()` every 15s while the transcode runs, renewing the ack deadline until it finishes. This is the standard JetStream pattern for long-running jobs and requires **no server-side change** (`InProgress` resets the deadline regardless of the configured `AckWait`).

## Verification

Two `transcoderOnly` workers sharing the consumer, one recording transcoded with `-preset veryslow -threads 1` (~12m44s):

- **With this fix:** `NumDelivered=1` throughout; only one worker ever started the job; single output file; no rsync race.
- **Without it (current behavior):** the job becomes redeliverable ~30s in and the idle worker picks up the redelivered copy within its 5s fetch interval, producing a duplicate concurrent transcode.
