### PR TITLE
fix(recorder): clean the real $XDG_RUNTIME_DIR/pulse so pulseaudio restarts cleanly

### DIFF
--- a/docker-build/entrypoint.sh
+++ b/docker-build/entrypoint.sh
@@ -3,11 +3,12 @@
 set -euxo pipefail
 
 # cleanup
-# NOTE: clean the actual pulseaudio runtime dir ($XDG_RUNTIME_DIR/pulse). The image
-# sets XDG_RUNTIME_DIR=/home/root/.cache/xdgr, but this previously removed
-# /root/.cache/xdgr/pulse, so a stale pid/socket survived a restart and made the next
-# `pulseaudio -D` fail ("Daemon startup failed") -> crash-loop under `set -e`.
-rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse "${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR environment variable is required but unset or empty}/pulse"
+# NOTE: also clean the actual pulseaudio runtime dir at /home/root/.cache/xdgr/pulse
+# (the image sets XDG_RUNTIME_DIR=/home/root/.cache/xdgr). Previously only
+# /root/.cache/xdgr/pulse was removed, so a stale pid/socket survived a restart and made
+# the next `pulseaudio -D` fail ("Daemon startup failed") -> crash-loop under `set -e`.
+# Additive: keeps the existing path, adds the real one; no new behavior, no env required.
+rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse /root/.cache/xdgr/pulse /home/root/.cache/xdgr/pulse
 # start pulseaudio
 pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit
 

--- a/docker-build/entrypoint.sh
+++ b/docker-build/entrypoint.sh
@@ -7,7 +7,7 @@ set -euxo pipefail
 # sets XDG_RUNTIME_DIR=/home/root/.cache/xdgr, but this previously removed
 # /root/.cache/xdgr/pulse, so a stale pid/socket survived a restart and made the next
 # `pulseaudio -D` fail ("Daemon startup failed") -> crash-loop under `set -e`.
-rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse "${XDG_RUNTIME_DIR:?}/pulse"
+rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse "${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR environment variable is required but unset or empty}/pulse"
 # start pulseaudio
 pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit
 

--- a/docker-build/entrypoint.sh
+++ b/docker-build/entrypoint.sh
@@ -3,7 +3,11 @@
 set -euxo pipefail
 
 # cleanup
-rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse /root/.cache/xdgr/pulse
+# NOTE: clean the actual pulseaudio runtime dir ($XDG_RUNTIME_DIR/pulse). The image
+# sets XDG_RUNTIME_DIR=/home/root/.cache/xdgr, but this previously removed
+# /root/.cache/xdgr/pulse, so a stale pid/socket survived a restart and made the next
+# `pulseaudio -D` fail ("Daemon startup failed") -> crash-loop under `set -e`.
+rm -rf /tmp/.X* /var/run/pulse /var/lib/pulse /root/.config/pulse "${XDG_RUNTIME_DIR:?}/pulse"
 # start pulseaudio
 pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit
 


### PR DESCRIPTION
## Problem

`docker-build/entrypoint.sh` removes `/root/.cache/xdgr/pulse` before starting PulseAudio, but `docker-build/Dockerfile` sets `ENV XDG_RUNTIME_DIR=/home/root/.cache/xdgr`. So PulseAudio's **actual** runtime directory — `$XDG_RUNTIME_DIR/pulse` = `/home/root/.cache/xdgr/pulse` — is never cleaned.

A container's writable layer persists across a `docker restart` (restart policy / host reboot), unlike `--force-recreate`. After an unclean exit (e.g. a host reboot SIGKILLs the container), a stale `pid`/socket is left behind in `/home/root/.cache/xdgr/pulse`. On the next start, `pulseaudio -D` fails:

```
W: [pulseaudio] main.c: This program is not intended to be run as root ...
E: [pulseaudio] main.c: Daemon startup failed.
```

Since the entrypoint runs under `set -euxo pipefail`, that failure kills the entrypoint, the container exits, and `restart: unless-stopped` turns it into a crash-loop. It's intermittent (depends on PID reuse after the reboot), which makes it confusing to diagnose — the recorder never reaches its NATS connection because it never gets past PulseAudio.

## Root cause

A path mismatch between the env var and the cleanup line:

| location | value |
|---|---|
| `docker-build/Dockerfile` | `ENV XDG_RUNTIME_DIR=/home/root/.cache/xdgr` |
| `docker-build/entrypoint.sh` | `rm -rf ... /root/.cache/xdgr/pulse` |

The cleanup was written assuming `XDG_RUNTIME_DIR=$HOME/.cache/xdgr` (with `HOME=/root`), but the Dockerfile points it at `/home/root/.cache/xdgr`, so the `rm -rf` never touches the real runtime dir.

## Fix

Clean `"${XDG_RUNTIME_DIR:?}/pulse"` (the real runtime dir) instead of the hardcoded `/root/.cache/xdgr/pulse`. Using the env var keeps it correct if the path ever changes; `:?` guards against an accidentally empty value (so it can never become `rm -rf /pulse`).

## Reproduction

```bash
docker run --rm --entrypoint bash mynaparrot/plugnmeet-recorder -c '
  mkdir -p "$XDG_RUNTIME_DIR/pulse"; echo 1 > "$XDG_RUNTIME_DIR/pulse/pid"  # stale pid a reboot leaves behind
  rm -rf /root/.cache/xdgr/pulse                                           # what the current entrypoint does (wrong path)
  pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit; echo "rc=$?"'
# current entrypoint: "Daemon startup failed", rc=1
# with this fix:      rc=0
```

Real-world trigger: a recorder container with a restart policy + a host reboot. `--force-recreate` (a clean writable layer) masks the issue, but it returns on the next reboot.
